### PR TITLE
Fix a README link

### DIFF
--- a/packages/website-frontend/src/app/repository/modal/modal.component.html
+++ b/packages/website-frontend/src/app/repository/modal/modal.component.html
@@ -47,7 +47,7 @@
           <ng-template ngbPanelContent>
             <p>
               See
-              <a href="https://github.com/stryker-mutator/stryker/tree/master/packages/stryker#reporters-string"
+              <a href="https://github.com/stryker-mutator/stryker/tree/master/packages/core#reporters-string"
                 target="_blank">stryker readme</a>
               for an explanation on how you can configure this key in your the dashboard reporter.
             </p>


### PR DESCRIPTION
When you enable the dashboard for a project, the README link was wrong.