### PR TITLE
feat(report): allow slashes in version

### DIFF
--- a/packages/badge-api/badge/handler.ts
+++ b/packages/badge-api/badge/handler.ts
@@ -10,7 +10,10 @@ export function handler(mapper: ShieldMapper): AzureFunction {
     const {
       slug,
       module: moduleName
-    } = context.bindingData;
+    } = context.bindingData as {
+      slug: string | undefined;
+      module: string | undefined;
+    };
     try {
       const { project, version } = Slug.parse(slug);
 

--- a/packages/common/src/slug.ts
+++ b/packages/common/src/slug.ts
@@ -44,4 +44,3 @@ function sanitize(rawSlug: string) {
   }
   return rawSlug;
 }
-

--- a/packages/common/src/slug.ts
+++ b/packages/common/src/slug.ts
@@ -20,7 +20,7 @@ export class Slug {
    * the database to see what the actual name is.
    * @param rawSlug the project name and version concatenated with a slash
    */
-  public static parse(rawSlug: string) {
+  public static parse(rawSlug: string | undefined) {
     rawSlug = sanitize(rawSlug);
     if (rawSlug) {
       const parts = rawSlug.split('/');
@@ -35,12 +35,16 @@ export class Slug {
   }
 }
 
-function sanitize(rawSlug: string) {
-  while (rawSlug.endsWith('/')) {
-    rawSlug = rawSlug.substr(0, rawSlug.length - 1);
+function sanitize(rawSlug: string | undefined) {
+  if (rawSlug === undefined) {
+    return undefined;
+  } else {
+    while (rawSlug.endsWith('/')) {
+      rawSlug = rawSlug.substr(0, rawSlug.length - 1);
+    }
+    while (rawSlug.startsWith('/')) {
+      rawSlug = rawSlug.substr(1);
+    }
+    return rawSlug;
   }
-  while (rawSlug.startsWith('/')) {
-    rawSlug = rawSlug.substr(1);
-  }
-  return rawSlug;
 }

--- a/packages/common/src/slug.ts
+++ b/packages/common/src/slug.ts
@@ -1,27 +1,47 @@
 export class InvalidSlugError extends Error {
 }
 
+const NR_OF_PROJECT_NAME_PARTS = 3;
+
+/**
+ * Represents a slug, meaning a project and version concatenated in a url.
+ * For example "github.com/stryker-mutator/stryker/master"
+ * Or "github.com/stryker-mutator/stryker/feat/allow/slashes"
+ */
 export class Slug {
 
   constructor(public readonly project: string, public readonly version: string) {
   }
 
+  /**
+   * Parses a raw slug into project and version.
+   * Will assume that the project is in the form "gitProvider/owner/name", so 3 parts
+   * Whenever we support gitlab we should probably move this to data-access and query
+   * the database to see what the actual name is.
+   * @param rawSlug the project name and version concatenated with a slash
+   */
   public static parse(rawSlug: string) {
+    rawSlug = sanitize(rawSlug);
     if (rawSlug) {
-      while (rawSlug.endsWith('/')) {
-        rawSlug = rawSlug.substr(0, rawSlug.length - 1);
-      }
-      while (rawSlug.startsWith('/')) {
-        rawSlug = rawSlug.substr(1);
-      }
-      const split = rawSlug.lastIndexOf('/');
-      if (!rawSlug || rawSlug.lastIndexOf('/') === -1) {
+      const parts = rawSlug.split('/');
+      if (parts.length < (NR_OF_PROJECT_NAME_PARTS + 1)) {
         throw new InvalidSlugError(`Missing version in "${rawSlug}"`);
       } else {
-        return new Slug(rawSlug.substr(0, split), rawSlug.substr(split + 1));
+        return new Slug(parts.slice(0, NR_OF_PROJECT_NAME_PARTS).join('/'), parts.slice(NR_OF_PROJECT_NAME_PARTS).join('/'));
       }
     } else {
       throw new InvalidSlugError(`Missing slug`);
     }
   }
 }
+
+function sanitize(rawSlug: string) {
+  while (rawSlug.endsWith('/')) {
+    rawSlug = rawSlug.substr(0, rawSlug.length - 1);
+  }
+  while (rawSlug.startsWith('/')) {
+    rawSlug = rawSlug.substr(1);
+  }
+  return rawSlug;
+}
+

--- a/packages/common/test/unit/slug.spec.ts
+++ b/packages/common/test/unit/slug.spec.ts
@@ -28,5 +28,11 @@ describe(Slug.name, () => {
         .throws(InvalidSlugError)
         .property('message', 'Missing slug');
     });
+
+    it('should throw an error if the slug is undefined', () => {
+      expect(() => Slug.parse(undefined))
+        .throws(InvalidSlugError)
+        .property('message', 'Missing slug');
+    });
   });
 });

--- a/packages/common/test/unit/slug.spec.ts
+++ b/packages/common/test/unit/slug.spec.ts
@@ -5,11 +5,16 @@ describe(Slug.name, () => {
 
   describe('parse', () => {
     it('should parse project name and version correctly', () => {
-      expect(Slug.parse('ab/c/dds%20ds')).deep.eq(new Slug('ab/c', 'dds%20ds'));
+      expect(Slug.parse('a/b/c/dds%20ds')).deep.eq(new Slug('a/b/c', 'dds%20ds'));
     });
 
     it('should remove trailing and leading slashes', () => {
-      expect(Slug.parse('//a/b/c///')).deep.eq(new Slug('a/b', 'c'));
+      expect(Slug.parse('//a/b/c/d///')).deep.eq(new Slug('a/b/c', 'd'));
+    });
+
+    it('should allow a version with slashes', () => {
+      expect(Slug.parse('github.com/stryker-mutator/stryker/feat/support/slashes'))
+        .deep.eq(new Slug('github.com/stryker-mutator/stryker', 'feat/support/slashes'));
     });
 
     it('should throw an error if the version is missing', () => {

--- a/packages/e2e/po/badge-api/badge-api.po.ts
+++ b/packages/e2e/po/badge-api/badge-api.po.ts
@@ -11,8 +11,8 @@ export class BadgeApiClient {
     });
   }
 
-  public badgeFor(repositorySlug: string, version: string): Promise<AxiosResponse<Shield>> {
-    return this.httpClient.get<Shield>(`/${repositorySlug}/${version}`);
+  public badgeFor(slug: string): Promise<AxiosResponse<Shield>> {
+    return this.httpClient.get<Shield>(`/${slug}`);
   }
 }
 

--- a/packages/e2e/spec/badge-api.spec.ts
+++ b/packages/e2e/spec/badge-api.spec.ts
@@ -17,7 +17,7 @@ describe('badge-api', () => {
       message: 'unknown',
       schemaVersion: 1
     };
-    const response = await client.badgeFor('a/b/c', 'master');
+    const response = await client.badgeFor('a/b/c/master');
     expect(response.data).deep.eq(expected);
   });
 
@@ -28,7 +28,19 @@ describe('badge-api', () => {
       message: '33.3%',
       schemaVersion: 1
     };
-    const response = await client.badgeFor('github.com/stryker-mutator-test-organization/hello-org', 'master');
+    const response = await client.badgeFor('github.com/stryker-mutator-test-organization/hello-org/master');
+    expect(response.data).deep.eq(expected);
+  });
+
+  it('should allow slashes in version name', async () => {
+    const expected: Shield = {
+      color: Color.Red,
+      label: 'Mutation score',
+      message: '33.3%',
+      schemaVersion: 1
+    };
+    await uploadReport(simpleReport('github.com/stryker-mutator-test-organization/hello-org', 'feat/test'));
+    const response = await client.badgeFor('github.com/stryker-mutator-test-organization/hello-org/feat/test');
     expect(response.data).deep.eq(expected);
   });
 });

--- a/packages/website-backend/src/api/ReportsController.ts
+++ b/packages/website-backend/src/api/ReportsController.ts
@@ -70,7 +70,7 @@ export default class ReportsController {
     if (result) {
       return ReportsController.toDto(result);
     } else {
-      throw new NotFound(`Report "${project}/${version}" does not exist`);
+      throw new NotFound(`Version "${version}" does not exist for "${project}".`);
     }
   }
 
@@ -89,7 +89,7 @@ export default class ReportsController {
       return Slug.parse(slug);
     } catch (error) {
       if (error instanceof InvalidSlugError) {
-        throw new NotFound(`Invalid slug "${slug}"`);
+        throw new NotFound(`Report "${slug}" does not exist`);
       } else {
         throw error;
       }

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -43,7 +43,8 @@
     },
     "typescript.tsdk": "stryker-dashboard\\node_modules\\typescript\\lib",
     "cSpell.words": [
-      "fdescribe"
+      "fdescribe",
+      "gitlab"
     ],
     "grunt.autoDetect": "off",
     "gulp.autoDetect": "off",


### PR DESCRIPTION
Don't enforce slashes in the version string to be espaced.

`feat%2Fdashboard` -> `feat/dashboard`

This is better for readability as well plays nice with azure routing.

For now we enforce the project name to have exactly 3 parts, for example  "github.com/org/name". We will need to rework that in the future to allow project names like "gitlab.com/org/team/backend/server".