### PR TITLE
fix(cdn): choose more stable CDN to deliver MTE

### DIFF
--- a/packages/website-frontend/src/index.html
+++ b/packages/website-frontend/src/index.html
@@ -11,6 +11,6 @@
 </head>
 <body>
   <stryker-dashboard></stryker-dashboard>
-  <script src="https://www.unpkg.com/mutation-testing-elements@1.7.14/dist/mutation-test-elements.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/mutation-testing-elements@1.7.14/dist/mutation-test-elements.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Update CDN from unpkg to jsdeliver, to deliver mutation-testing-elements, as it seems more stable.

Fixes #215