### PR TITLE
ci: Limit concurrent jobs executing e2e tests on Acceptance

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,7 @@ jobs:
         path: version.txt
 
   deploy:
-    name: Deploy to Acceptance
+    name: Deploy to Acceptance and E2E test
     needs: build-and-release
     runs-on: ubuntu-latest
     environment: Acceptance
@@ -77,14 +77,7 @@ jobs:
       run: |
         node tasks/check-version dashboard https://stryker-dashboard-acceptance.azurewebsites.net/api/version $(cat version/version.txt)
         node tasks/check-version badge-api https://stryker-mutator-badge-api-acceptance.azurewebsites.net/api $(cat version/version.txt)
-
-  run-e2e-tests:
-    name: Run e2e tests
-    needs: deploy
-    runs-on: ubuntu-latest
-    concurrency: Acceptance
-    steps:
-    - uses: actions/checkout@v2
+# Run E2E    
     - name: Install dependencies
       run: npm ci
     - name: Install browsers

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,4 @@
-on: ['pull_request', 'workflow_dispatch']
+on: ['pull_request']
 
 name: e2e
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,4 @@
-on: ['pull_request']
+on: ['pull_request', 'workflow_dispatch']
 
 name: e2e
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -76,7 +76,7 @@ jobs:
       run: |
         node tasks/check-version dashboard https://stryker-dashboard-acceptance.azurewebsites.net/api/version $(cat version/version.txt)
         node tasks/check-version badge-api https://stryker-mutator-badge-api-acceptance.azurewebsites.net/api $(cat version/version.txt)
-# Run E2E    
+ 
     - name: Install dependencies
       run: npm ci
     - name: Install browsers

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,7 +3,6 @@ on: ['pull_request']
 name: e2e
 
 jobs:
-
   build-and-release:
     name: Build and Release
     runs-on: ubuntu-latest
@@ -43,8 +42,8 @@ jobs:
         name: version
         path: version.txt
 
-  deploy:
-    name: Deploy to Acceptance and E2E test
+  deploy-and-test:
+    name: Deploy to Acceptance and run E2E tests
     needs: build-and-release
     runs-on: ubuntu-latest
     environment: Acceptance

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,6 +47,8 @@ jobs:
     name: Deploy to Acceptance
     needs: build-and-release
     runs-on: ubuntu-latest
+    environment: Acceptance
+    concurrency: Acceptance
     steps:
     - uses: actions/checkout@v2
     - name: 'Download artifact: version'
@@ -80,6 +82,7 @@ jobs:
     name: Run e2e tests
     needs: deploy
     runs-on: ubuntu-latest
+    concurrency: Acceptance
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies


### PR DESCRIPTION
Multiple builds started at the same time may cause concurrent deployments to Acceptance. This can mess up the e2e tests.

![image](https://github.com/stryker-mutator/stryker-dashboard/assets/3595932/40ae2b62-62a6-4e9d-9bec-4742a55e660c)
