### PR TITLE
ci: Limit CI trigger to master branch and all tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,12 @@
 name: CI
 
 on:
-  push: ~
-  pull_request: ~
+  push:
+    branches:
+      - 'master'
+    tags:
+     - '*'
+  pull_request:
   schedule:
     - cron:  '0 12 * * *'
 


### PR DESCRIPTION
Prevents double trigger and using up pipeline resources for no reason on PRs