### PR TITLE
chore: disable npm provenance for e2e canary publish

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,9 +6,6 @@ jobs:
   build-and-release:
     name: Build and Release
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write # to enable use of OIDC for npm provenance
     steps:
     - uses: actions/checkout@v4
     - name: Set NPM Env
@@ -30,8 +27,6 @@ jobs:
         npx lerna version ${NPM_PACKAGE_VERSION} --no-git-tag-version --no-push --exact --force-publish --yes --no-conventional-commits
         git commit -am "temp-commit"
         npx lerna publish from-package --dist-tag canary --no-git-reset --yes --no-verify-access
-      env:
-        NPM_CONFIG_PROVENANCE: true
     - name: Docker build & Push
       uses: nick-invision/retry@v3.0.0
       with: 


### PR DESCRIPTION
This causes issues with external contributors where the CI token doesn't have the correct rights