### PR TITLE
fix: update security headers

### DIFF
--- a/packages/website-backend/src/index.ts
+++ b/packages/website-backend/src/index.ts
@@ -50,16 +50,19 @@ function configureSecurityHeaders(app: INestApplication) {
   app.enableCors({ origin: true, credentials: true });
   app.use(
     helmet({
+      strictTransportSecurity: {
+        maxAge: 31536000,
+        preload: true,
+      },
       contentSecurityPolicy: {
         directives: {
           imgSrc: [
             `'self'`,
             'data:',
             'https://stryker-mutator.io',
-            'avatars.githubusercontent.com',
-            'img.shields.io',
+            'https://avatars.githubusercontent.com',
+            'https://img.shields.io',
           ],
-          scriptSrc: [`'self'`, `'unsafe-inline'`],
           scriptSrcAttr: [`'unsafe-inline'`],
         },
       },


### PR DESCRIPTION
- Updates Strict-Transport-Security to a longer (recommended) duration and include preload
- Add https:// scheme to external domains
- Remove the scriptSrc directive, which makes it default to 'self' instead of 'unsafe-inline'
