### PR TITLE
build: use docker actions steps for building image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,15 +27,37 @@ jobs:
       run: npx lerna publish from-git --yes --no-verify-access
       env:
         NPM_CONFIG_PROVENANCE: true
-    - name: Docker build & Tag
-      run: | # Add a sleep to give npmjs.com the time to get the versions consistent 
-        sleep 30s
-        cd docker
-        NPM_PACKAGE_VERSION=${GITHUB_REF:11}
-        docker build -t strykermutator/dashboard:${NPM_PACKAGE_VERSION} -t strykermutator/dashboard:latest --build-arg version=${NPM_PACKAGE_VERSION} .
-        docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
-        docker push strykermutator/dashboard:${NPM_PACKAGE_VERSION}
-        docker push strykermutator/dashboard:latest
+
+    # Add a sleep to give npmjs.com the time to get the versions consistent 
+    - run: sleep 15s
+    - name: Log in to the Container registry
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: strykermutator/dashboard
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      id: build
+      with:
+        context: ./docker
+        push: true
+        build-args: 'version=${{ steps.meta.outputs.version }}'
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        annotations: ${{ steps.meta.outputs.annotations }}
+        platforms: linux/amd64,linux/arm64/v8
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
   deploy-dashboard:
     name: 'Deploy Dashboard'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,8 @@ jobs:
   build-and-release:
     name: Build and Release
     runs-on: ubuntu-latest
+    outputs:
+      npm-package-version: ${{ steps.version.outputs.npm-package-version }}
     steps:
     - uses: actions/checkout@v4
     - name: Set NPM Env
@@ -17,34 +19,52 @@ jobs:
     - name: Install dependencies
       run: npm ci
     - name: Choose version
+      id: version
       run: 'node tasks/set-npm-canary-version.js'
     - name: Build
       run: npm run build
     - name: Lerna publish canary version
       run: |
-        git config --global user.name github-actions
-        git config --global user.email "github-actions@github.com"
-        npx lerna version ${NPM_PACKAGE_VERSION} --no-git-tag-version --no-push --exact --force-publish --yes --no-conventional-commits
+        git config --global user.name "stryker-mutator[bot]"
+        git config --global user.email 158062761+stryker-mutator[bot]@users.noreply.github.com
+        npx lerna version ${{ steps.version.outputs.npm-package-version }} --no-git-tag-version --no-push --exact --force-publish --yes --no-conventional-commits
         git commit -am "temp-commit"
         npx lerna publish from-package --dist-tag canary --no-git-reset --yes --no-verify-access
-    - name: Docker build & Push
-      uses: nick-invision/retry@v3.0.0
-      with: 
-        timeout_minutes: 1
-        max_attempts: 3
-        command: |
-          echo "Docker build $NPM_PACKAGE_VERSION"
-          cd docker
-          docker build -t strykermutator/dashboard:${{ github.sha }}  --build-arg version=${NPM_PACKAGE_VERSION} .
-          docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
-          docker push strykermutator/dashboard:${{ github.sha }} 
-    - name: Write version number
-      run: echo $NPM_PACKAGE_VERSION > version.txt
-    - name: 'Upload artifact: version'
-      uses: actions/upload-artifact@v4
-      with: 
-        name: version
-        path: version.txt
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: strykermutator/dashboard
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}},value=v${{ steps.version.outputs.npm-package-version }}
+
+    # Add a sleep to give npmjs.com the time to get the versions consistent 
+    - run: sleep 15s
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      id: build
+      with:
+        context: ./docker
+        push: true
+        build-args: 'version=${{ steps.meta.outputs.version }}'
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        annotations: ${{ steps.meta.outputs.annotations }}
+        platforms: linux/amd64,linux/arm64/v8
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
   deploy-and-test:
     name: Deploy to Acceptance and run E2E tests
@@ -54,13 +74,8 @@ jobs:
     concurrency: Acceptance
     steps:
     - uses: actions/checkout@v4
-    - name: 'Download artifact: version'
-      uses: actions/download-artifact@v4
-      with:
-        name: version
-        path: 'version'
     - name: Download & install badge-api package
-      run: ./tasks/download-badge-api-package.sh $(cat version/version.txt)
+      run: ./tasks/download-badge-api-package.sh ${{ needs.build-and-release.outputs.npm-package-version }}
     - uses: azure/login@v2
       name: Azure login
       with:
@@ -75,11 +90,11 @@ jobs:
       uses: azure/webapps-deploy@v3
       with:
         app-name: 'stryker-dashboard-acceptance'
-        images: 'strykermutator/dashboard:${{ github.sha }}'
+        images: 'strykermutator/dashboard:${{ needs.build-and-release.outputs.npm-package-version }}'
     - name: 'Verify deployment'
       run: |
-        node tasks/check-version dashboard https://stryker-dashboard-acceptance.azurewebsites.net/api/version $(cat version/version.txt)
-        node tasks/check-version badge-api https://stryker-mutator-badge-api-acceptance.azurewebsites.net/api $(cat version/version.txt)
+        node tasks/check-version dashboard https://stryker-dashboard-acceptance.azurewebsites.net/api/version ${{ needs.build-and-release.outputs.npm-package-version }}
+        node tasks/check-version badge-api https://stryker-mutator-badge-api-acceptance.azurewebsites.net/api ${{ needs.build-and-release.outputs.npm-package-version }}
  
     - uses: actions/setup-node@v4
       with:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,18 @@
-FROM node:20.11.1-alpine
-ARG version=latest
+FROM node:20.11.1-alpine as base
 ENV NODE_ENV production
 USER node
 
 WORKDIR /app
-RUN npm init --yes
-RUN npm install @stryker-mutator/dashboard-backend@$version
 
-HEALTHCHECK CMD npx dashboard-healthcheck
+# Separate build stage to cache npm install and not include npm cache in the final image
+FROM base as build
+ARG version=latest
+RUN npm init --yes
+RUN --mount=type=cache,id=npm,target=/root/.npm npm install @stryker-mutator/dashboard-backend@$version
+
+FROM base
+COPY --from=build /app/ /app/
+
+HEALTHCHECK CMD npx --offline dashboard-healthcheck
 EXPOSE 1337
-ENTRYPOINT [ "npx", "dashboard-backend" ]
+ENTRYPOINT [ "npx", "--offline", "dashboard-backend" ]

--- a/tasks/check-version.js
+++ b/tasks/check-version.js
@@ -73,12 +73,12 @@ function verifyDashboardVersion(resp) {
     let data = '';
     resp.on('data', (chunk) => (data += chunk));
     resp.on('end', () => {
-      const actual = JSON.parse(data);
-      const expected = {
-        dashboard: expectedVersion,
-        frontend: expectedVersion,
-      };
       try {
+        const actual = JSON.parse(data);
+        const expected = {
+          dashboard: expectedVersion,
+          frontend: expectedVersion,
+        };
         if (
           actual.dashboard !== expected.dashboard ||
           actual.frontend !== expected.frontend

--- a/tasks/set-npm-canary-version.js
+++ b/tasks/set-npm-canary-version.js
@@ -2,7 +2,7 @@
 // @ts-check
 
 /**
- * This file will determine the next canary version number, setting it in the NPM_PACKAGE_VERSION variable for all next actions to use.
+ * This file will determine the next canary version number, setting it in the npm-package-version output variable for all next actions to use.
  * Instead of Lerna's algorithm, it validates that the next version does not yet exist.
  * Unfortunately Lerna itself doesn't support this
  */
@@ -15,7 +15,7 @@ const { version: currentVersion } = JSON.parse(
 );
 
 determineNextCanaryVersion().catch((err) => {
-  console.error(err);
+  core.error(err);
   process.exitCode = 1;
 });
 
@@ -28,8 +28,9 @@ async function determineNextCanaryVersion() {
   ).json();
   const revision = determineNextFreeRevision(nextPatchVersion, preId, versions);
   const npmVersion = formatVersion(nextPatchVersion, preId, revision);
-  core.exportVariable('NPM_PACKAGE_VERSION', npmVersion);
-  console.log(npmVersion);
+  core.setOutput('npm-package-version', npmVersion);
+  core.info(npmVersion);
+  core.notice(`Next canary version is ${npmVersion}`);
 }
 
 /**


### PR DESCRIPTION
Uses github actions steps for building the Docker image, rather than the CLI. The steps are slightly more verbose, but this has some advantages:

- easier to specify build arguments, tags and labels.
  -  For example, release builds are automatically tagged as the tag name, and `:latest`. We could also easily publish to the github container registry with this, if wanted.
- Automatically adds relevant [OCI labels](https://snyk.io/blog/how-and-when-to-use-docker-labels-oci-container-annotations/)
- Adds a multi-platform build to build `linux/amd64` and `linux/arm64` images.
- Adds a cache for the Docker build, to speed up the build process.
- And separates the `npm install` step from the final image, to reduce the image size.
