### PR TITLE
fix: add unsafe-eval to csp script-src directives

### DIFF
--- a/packages/website-backend/src/index.ts
+++ b/packages/website-backend/src/index.ts
@@ -63,7 +63,7 @@ function configureSecurityHeaders(app: INestApplication) {
             'https://avatars.githubusercontent.com',
             'https://img.shields.io',
           ],
-          scriptSrcAttr: [`'unsafe-inline'`],
+          scriptSrcAttr: [`'unsafe-inline'`, `'unsafe-eval'`],
         },
       },
     }),


### PR DESCRIPTION
(Potentially) fixes #592

Ideally we would be able to disable unsafe-eval (and unsafe-inline), but this at least gets things working again