### PR TITLE
feat(docker): also publish image to ghcr.io

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # to enable use of OIDC for npm provenance
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - name: Set NPM Env
@@ -35,6 +36,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -43,7 +50,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: strykermutator/dashboard
+          images: |
+            strykermutator/dashboard
+            ghcr.io/stryker-mutator/dashboard
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -75,7 +84,7 @@ jobs:
         uses: azure/webapps-deploy@v3
         with:
           app-name: 'stryker-badge'
-          images: 'strykermutator/dashboard:latest'
+          images: 'ghcr.io/stryker-mutator/dashboard:latest'
       - name: 'Verify deployment'
         run: node tasks/check-version dashboard https://dashboard.stryker-mutator.io/api/version ${GITHUB_REF:11}
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       npm-package-version: ${{ steps.version.outputs.npm-package-version }}
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - name: Set NPM Env
@@ -34,11 +37,12 @@ jobs:
           git commit -am "temp-commit"
           npx lerna publish from-package --dist-tag canary --no-git-reset --yes --no-verify-access
 
-      - name: Log in to the Container registry
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -47,7 +51,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: strykermutator/dashboard
+          images: ghcr.io/stryker-mutator/dashboard
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -94,11 +98,11 @@ jobs:
         uses: azure/webapps-deploy@v3
         with:
           app-name: 'stryker-dashboard-acceptance'
-          images: 'strykermutator/dashboard:${{ needs.build-and-release.outputs.npm-package-version }}'
+          images: 'ghcr.io/stryker-mutator/dashboard:${{ needs.build-and-release.outputs.npm-package-version }}'
       - name: 'Verify deployment'
         run: |
-          node tasks/check-version dashboard https://stryker-dashboard-acceptance.azurewebsites.net/api/version ${{ needs.build-and-release.outputs.npm-package-version }}
           node tasks/check-version badge-api https://stryker-mutator-badge-api-acceptance.azurewebsites.net/api ${{ needs.build-and-release.outputs.npm-package-version }}
+          node tasks/check-version dashboard https://stryker-dashboard-acceptance.azurewebsites.net/api/version ${{ needs.build-and-release.outputs.npm-package-version }}
 
       - uses: actions/setup-node@v4
         with:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Next, you need to define the following environment variables in a Docker [enviro
 
 ### Start the application
 
-To start the application, you can now simply run `docker run --env-file env.list -p 1337:1337 strykermutator/dashboard`. This will spin-up a Docker container with the image that was build earlier; provide it with your environment variables set in the `env-list` file; and open port 1337 so you can access it on your local machine.
+To start the application, you can now simply run `docker run --env-file env.list -p 1337:1337 ghcr.io/stryker-mutator/dashboard`. This will spin-up a Docker container with the image that was build earlier; provide it with your environment variables set in the `env-list` file; and open port 1337 so you can access it on your local machine.
 
 Stryker Dashboard should now be available at [http://localhost:1337](http://localhost:1337).
 


### PR DESCRIPTION
This provides more options, is probably slightly faster when deploying (same data-center) and GitHub container registry has fewer rate-limiting issues
