### PR TITLE
feat: offload schema validation to a worker pool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22640,7 +22640,8 @@
         "compression": "1.7.5",
         "helmet": "8.0.0",
         "passport-github2": "0.1.12",
-        "passport-jwt": "4.0.1"
+        "passport-jwt": "4.0.1",
+        "workerpool": "9.2.0"
       },
       "bin": {
         "dashboard-backend": "bin/dashboard-backend.js",
@@ -23096,6 +23097,12 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "packages/website-backend/node_modules/workerpool": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.2.0.tgz",
+      "integrity": "sha512-PKZqBOCo6CYkVOwAxWxQaSF2Fvb5Iv2fCeTP7buyWI2GiynWr46NcXSgK/idoV6e60dgCBfgYc+Un3HMvmqP8w==",
+      "license": "Apache-2.0"
     },
     "packages/website-contract": {
       "name": "@stryker-mutator/dashboard-contract",

--- a/packages/website-backend/package.json
+++ b/packages/website-backend/package.json
@@ -38,7 +38,8 @@
     "compression": "1.7.5",
     "helmet": "8.0.0",
     "passport-github2": "0.1.12",
-    "passport-jwt": "4.0.1"
+    "passport-jwt": "4.0.1",
+    "workerpool": "9.2.0"
   },
   "devDependencies": {
     "@nestjs/schematics": "11.0.0",

--- a/packages/website-backend/src/controllers/real-time-reports.controller.ts
+++ b/packages/website-backend/src/controllers/real-time-reports.controller.ts
@@ -119,9 +119,11 @@ export default class RealTimeReportsController {
     }
 
     const { project, version } = Slug.parse(slug.join('/'));
-    await this.#apiKeyValidator.validateApiKey(authorizationHeader, project);
+    const [, errors] = await Promise.all([
+      this.#apiKeyValidator.validateApiKey(authorizationHeader, project),
+      this.#reportValidator.validateMutants(mutants),
+    ]);
 
-    const errors = this.#reportValidator.validateMutants(mutants);
     if (errors !== undefined) {
       throw new BadRequestException(`Invalid mutants: ${errors}`);
     }
@@ -152,7 +154,7 @@ export default class RealTimeReportsController {
     const { project, version } = parseSlug(slug.join('/'));
     await this.#apiKeyValidator.validateApiKey(authorizationHeader, project);
 
-    const errors = this.#reportValidator.findErrors(result);
+    const errors = await this.#reportValidator.findErrors(result);
     if (errors) {
       throw new BadRequestException('Invalid report. ${errors}');
     }

--- a/packages/website-backend/src/services/ValidatorWorker.ts
+++ b/packages/website-backend/src/services/ValidatorWorker.ts
@@ -1,0 +1,64 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+import type { ValidateFunction } from 'ajv';
+import { Ajv } from 'ajv';
+import _addFormats from 'ajv-formats';
+import type { MutantResult, MutationTestResult } from 'mutation-testing-report-schema';
+import { schema } from 'mutation-testing-report-schema';
+import workerpool from 'workerpool';
+
+// https://github.com/ajv-validator/ajv-formats/issues/85#issuecomment-2262652443
+const addFormats = _addFormats as unknown as typeof _addFormats.default;
+
+// ----------------
+// Schema validation is CPU-intensive on large reports. To prevent blocking the main thread, we offload the validation to a worker pool.
+// This file is the worker script that runs in the worker pool.
+// ----------------
+
+function initSchemaValidator() {
+  const ajv = new Ajv();
+  addFormats(ajv);
+
+  const mutantSchema = {
+    ...schema.properties.files.additionalProperties.properties.mutants,
+    definitions: schema.definitions,
+  };
+  mutantSchema.items.required = ['id', 'status'];
+
+  return {
+    fullSchemaValidate: ajv.compile<MutationTestResult>(schema),
+    mutantSchemaValidate: ajv.compile<Partial<MutantResult>[]>(mutantSchema),
+    errorsText: ajv.errorsText.bind(ajv),
+  };
+}
+const { fullSchemaValidate, mutantSchemaValidate, errorsText } = initSchemaValidator();
+
+function validate<T>(data: unknown, validator: ValidateFunction<T>): undefined | string {
+  try {
+    if (!validator(data)) {
+      return errorsText(validator.errors);
+    } else {
+      return;
+    }
+  } catch (err) {
+    console.error('AJV validation error', err);
+    return;
+  }
+}
+
+function validateReport(report: object): undefined | string {
+  return validate(report, fullSchemaValidate);
+}
+export type ValidateReport = typeof validateReport;
+
+function validateMutants(mutants: Partial<MutantResult>[] | null): undefined | string {
+  return validate(mutants, mutantSchemaValidate);
+}
+export type ValidateMutants = typeof validateMutants;
+
+// Register the functions in the workerpool
+workerpool.worker({
+  validateReport,
+  validateMutants,
+});

--- a/packages/website-backend/test/unit/controllers/auth.controller.spec.ts
+++ b/packages/website-backend/test/unit/controllers/auth.controller.spec.ts
@@ -37,6 +37,10 @@ describe(AuthController.name, () => {
     await app.init();
   });
 
+  afterEach(async () => {
+    await app.close();
+  });
+
   describe('POST /auth/github', () => {
     it("should respond with the 'jwt' token", async () => {
       // Arrange

--- a/packages/website-backend/test/unit/controllers/organizations.controller.spec.ts
+++ b/packages/website-backend/test/unit/controllers/organizations.controller.spec.ts
@@ -33,6 +33,10 @@ describe(OrganizationsController.name, () => {
     await app.init();
   });
 
+  afterEach(async () => {
+    await app.close();
+  });
+
   describe('HTTP GET /organizations/:name/repositories', () => {
     it('should retrieve the organizations', async () => {
       // Arrange

--- a/packages/website-backend/test/unit/controllers/real-time-reports.controller.spec.ts
+++ b/packages/website-backend/test/unit/controllers/real-time-reports.controller.spec.ts
@@ -68,6 +68,10 @@ describe(RealTimeReportsController.name, () => {
     await app.init();
   });
 
+  afterEach(async () => {
+    await app.close();
+  });
+
   describe('HTTP GET /*', () => {
     it('should return not found when project does not exist', async () => {
       dataAccess.mutationTestingReportService.findOne.resolves(null);

--- a/packages/website-backend/test/unit/controllers/reports.controller.spec.ts
+++ b/packages/website-backend/test/unit/controllers/reports.controller.spec.ts
@@ -44,6 +44,10 @@ describe(ReportsController.name, () => {
     await app.init();
   });
 
+  afterEach(async () => {
+    await app.close();
+  });
+
   describe('HTTP GET /:slug', () => {
     it('should retrieve the expected report', async () => {
       // Arrange

--- a/packages/website-backend/test/unit/controllers/repositories.controller.spec.ts
+++ b/packages/website-backend/test/unit/controllers/repositories.controller.spec.ts
@@ -47,6 +47,10 @@ describe('RepositoriesController', () => {
     await app.init();
   });
 
+  afterEach(async () => {
+    await app.close();
+  });
+
   describe('PATCH /github/:owner/:name', () => {
     it('should enable the repository with a new api key if enabled = true', async () => {
       updateStub.resolves();

--- a/packages/website-backend/test/unit/controllers/user.controller.spec.ts
+++ b/packages/website-backend/test/unit/controllers/user.controller.spec.ts
@@ -56,6 +56,10 @@ describe(UserController.name, () => {
     await app.init();
   });
 
+  afterEach(async () => {
+    await app.close();
+  });
+
   describe('HTTP GET /user', () => {
     it('should retrieve current user', async () => {
       const githubResult = githubFactory.login({

--- a/packages/website-backend/test/unit/services/ReportValidator.spec.ts
+++ b/packages/website-backend/test/unit/services/ReportValidator.spec.ts
@@ -10,34 +10,38 @@ describe(ReportValidator.name, () => {
     sut = new ReportValidator();
   });
 
+  afterEach(async () => {
+    await sut.onApplicationShutdown();
+  });
+
   describe('validateMutants', () => {
-    it('should validate partial mutants correctly', () => {
+    it('should validate partial mutants correctly', async () => {
       const payload: Partial<MutantResult>[] = [
         { id: '1', status: 'Killed' },
         { id: '2', status: 'Survived' },
       ];
 
-      const errors = sut.validateMutants(payload);
+      const errors = await sut.validateMutants(payload);
 
       expect(errors).to.be.undefined;
     });
 
-    it('should error when required properties are missing', () => {
+    it('should error when required properties are missing', async () => {
       const payload = [{}, {}];
 
-      const errors = sut.validateMutants(payload);
+      const errors = await sut.validateMutants(payload);
 
       expect(errors).to.be.eq("data/0 must have required property 'id'");
     });
 
-    it('should error when not all mutants have all required properties', () => {
+    it('should error when not all mutants have all required properties', async () => {
       const payload: Partial<MutantResult>[] = [
         { id: '1', status: 'Killed' },
         { id: '2', status: 'Survived' },
         { id: '3' },
       ];
 
-      const errors = sut.validateMutants(payload);
+      const errors = await sut.validateMutants(payload);
 
       expect(errors).to.be.eq("data/2 must have required property 'status'");
     });


### PR DESCRIPTION
Relates to #1183 

Uses [workerpool](https://www.npmjs.com/package/workerpool) to offload schema validation to a worker pool. This prevents blocking the main thread when validating large reports, keeping the application responsive. It also allows the dashboard to validate multiple reports concurrently.
