### PR TITLE
feat(reports): add DELETE report endpoint

### DIFF
--- a/packages/badge-api/test/badge/ShieldMapper.spec.ts
+++ b/packages/badge-api/test/badge/ShieldMapper.spec.ts
@@ -18,6 +18,7 @@ describe(ShieldMapper.name, () => {
       insertOrMerge: sinon.stub(),
       replace: sinon.stub(),
       insert: sinon.stub(),
+      delete: sinon.stub(),
     };
     sut = new ShieldMapper(mutationTestingReportStub);
   });

--- a/packages/data-access/src/mappers/Mapper.ts
+++ b/packages/data-access/src/mappers/Mapper.ts
@@ -12,4 +12,5 @@ export interface Mapper<TModel, TPartitionKeyFields extends keyof TModel, TRowKe
   replace(model: TModel, etag: string): Promise<Result<TModel>>;
   findOne(identifier: Pick<TModel, TPartitionKeyFields | TRowKeyFields>): Promise<Result<TModel> | null>;
   findAll(query: DashboardQuery<TModel, TPartitionKeyFields, TRowKeyFields>): Promise<Result<TModel>[]>;
+  delete(identifier: Pick<TModel, TPartitionKeyFields | TRowKeyFields>): Promise<void>;
 }

--- a/packages/data-access/src/mappers/TableStorageMapper.ts
+++ b/packages/data-access/src/mappers/TableStorageMapper.ts
@@ -105,6 +105,21 @@ export default class TableStorageMapper<
     }
   }
 
+  public async delete(identity: Pick<TModel, TPartitionKeyFields | TRowKeyFields>): Promise<void> {
+    try {
+      await this.#tableClient.deleteEntity(
+        encodeKey(this.ModelClass.createPartitionKey(identity)),
+        encodeKey(this.ModelClass.createRowKey(identity) || ''),
+      );
+    } catch (err) {
+      if (hasErrorCode(err, errCodes.RESOURCE_NOT_FOUND)) {
+        // Already deleted, no need to throw
+      } else {
+        throw err;
+      }
+    }
+  }
+
   private toModel(entity: TableEntityResult<TModel>): Result<TModel> {
     const value = new this.ModelClass();
     this.ModelClass.identify(value, decodeKey(entity.partitionKey!), decodeKey(entity.rowKey!));

--- a/packages/data-access/test/helpers/mock.ts
+++ b/packages/data-access/test/helpers/mock.ts
@@ -18,6 +18,7 @@ export function createTableMapperMock<A, B extends keyof A, C extends keyof A>()
     findAll: sinon.stub(),
     replace: sinon.stub(),
     insert: sinon.stub(),
+    delete: sinon.stub(),
   };
 }
 

--- a/packages/data-access/test/unit/mappers/TableStorageMapper.spec.ts
+++ b/packages/data-access/test/unit/mappers/TableStorageMapper.spec.ts
@@ -177,6 +177,25 @@ describe(TModel.name, () => {
     });
   });
 
+  describe('delete', () => {
+    it('should delete the entity', async () => {
+      tableClient.deleteEntity.resolves();
+      await sut.delete({
+        partitionId: 'partId',
+        rowId: 'rowId',
+      });
+      sinon.assert.calledWith(tableClient.deleteEntity, 'partId', 'rowId');
+    });
+
+    it('should not throw if the entity does not exist', async () => {
+      tableClient.deleteEntity.rejects(new StorageError('ResourceNotFound'));
+      await sut.delete({
+        partitionId: 'partId',
+        rowId: 'rowId',
+      });
+    });
+  });
+
   function createRawEntity(overrides?: Partial<FooModel>, etag?: string): TableEntity<Pick<FooModel, 'bar'>> {
     const foo: Pick<FooModel, 'bar'> = {
       bar: overrides?.bar ?? 42,

--- a/packages/data-access/test/unit/services/MutationTestingReportService.spec.ts
+++ b/packages/data-access/test/unit/services/MutationTestingReportService.spec.ts
@@ -345,23 +345,88 @@ describe(MutationTestingReportService.name, () => {
 
   describe('delete', () => {
     it('should delete the blob', async () => {
+      const projectName = 'p';
+      const version = 'v';
+      const otherModule = {
+        moduleName: 'core',
+        mutationScore: 80,
+        projectName,
+        version,
+      };
+      reportMapperMock.findAll.resolves([{ etag: '', model: otherModule }]);
+
       // Arrange
       const id = {
         moduleName: 'm',
-        projectName: 'p',
-        version: 'v',
+        projectName,
+        version,
       };
 
       // Act
-      await sut.delete(id);
+      await sut.delete(id, logger);
 
       // Assert
       expect(resultMapperMock.delete.calledOnce).to.be.true;
       sinon.assert.calledWith(resultMapperMock.delete, {
         moduleName: 'm',
-        projectName: 'p',
-        version: 'v',
+        projectName,
+        version,
       });
+      expect(reportMapperMock.delete.calledOnce).to.be.true;
+      sinon.assert.calledWith(reportMapperMock.delete, {
+        moduleName: 'm',
+        projectName,
+        version,
+      });
+      expect(reportMapperMock.findAll.calledOnce).to.be.true;
+      sinon.assert.calledWith(resultMapperMock.findOne, otherModule);
+    });
+
+    it('should delete modules when deleting the root', async () => {
+      const projectName = 'p';
+      const version = 'v';
+      const otherModule = {
+        moduleName: 'core',
+        mutationScore: 80,
+        projectName,
+        version,
+      };
+      reportMapperMock.findAll.resolves([{ etag: '', model: otherModule }]);
+      // Arrange
+      const id = {
+        moduleName: undefined,
+        projectName,
+        version,
+      };
+
+      // Act
+      await sut.delete(id, logger);
+
+      // Assert
+      expect(resultMapperMock.delete.calledTwice).to.be.true;
+      sinon.assert.calledWith(resultMapperMock.delete, {
+        moduleName: undefined,
+        projectName,
+        version,
+      });
+      sinon.assert.calledWith(resultMapperMock.delete, {
+        moduleName: 'core',
+        projectName,
+        version,
+      });
+      expect(reportMapperMock.delete.calledTwice).to.be.true;
+      sinon.assert.calledWith(reportMapperMock.delete, {
+        moduleName: undefined,
+        projectName,
+        version,
+      });
+      sinon.assert.calledWith(reportMapperMock.delete, {
+        moduleName: 'core',
+        projectName,
+        version,
+      });
+
+      expect(reportMapperMock.findAll.calledOnce).to.be.true;
     });
   });
 });

--- a/packages/e2e/po/reports/report-client.po.ts
+++ b/packages/e2e/po/reports/report-client.po.ts
@@ -89,6 +89,16 @@ export class ReportClient {
     });
   }
 
+  async deleteReport(result: Report) {
+    const apiKey = await this.enableRepository(result.projectName);
+    return await this.request.delete(this.#getUrl('/api/reports', result), {
+      failOnStatusCode: true,
+      headers: {
+        ['X-Api-Key']: apiKey,
+      },
+    });
+  }
+
   async deletePendingReport(result: Report) {
     const apiKey = await this.enableRepository(result.projectName);
     return await this.request.delete(this.#getUrl('/api/real-time', result), {

--- a/packages/e2e/spec/report-api.spec.ts
+++ b/packages/e2e/spec/report-api.spec.ts
@@ -63,4 +63,13 @@ test.describe('Report api', () => {
       expect(response).toEqual(expectedResponse);
     });
   });
+
+  test.describe('HTTP delete', () => {
+    test('should return 204', async () => {
+      const response = await client.deleteReport(
+        simpleReportV1('github.com/stryker-mutator-test-organization/hello-org', 'feat/report'),
+      );
+      expect(response.status()).toBe(204);
+    });
+  });
 });

--- a/packages/website-backend/src/controllers/real-time-reports.controller.ts
+++ b/packages/website-backend/src/controllers/real-time-reports.controller.ts
@@ -103,7 +103,7 @@ export default class RealTimeReportsController {
     server.sendFinished();
 
     this.#orchestrator.removeResponseHandler(id);
-    await Promise.all([this.#blobService.delete(id), this.#reportService.delete(id)]);
+    await Promise.all([this.#blobService.delete(id), this.#reportService.delete(id, this.#logger)]);
   }
 
   @Post('/*slug')

--- a/packages/website-backend/test/helpers/TestServer.ts
+++ b/packages/website-backend/test/helpers/TestServer.ts
@@ -72,6 +72,7 @@ export class DataAccessMock implements IDataAccessMock {
     insertOrMerge: sinon.stub(),
     insert: sinon.stub(),
     replace: sinon.stub(),
+    delete: sinon.stub(),
   };
   mutationTestingReportService = sinon.createStubInstance(dal.MutationTestingReportService);
   blobService = sinon.createStubInstance(dal.RealTimeMutantsBlobService);


### PR DESCRIPTION
Adds an API endpoint to delete a report. Supplying a module will delete only that module and re-aggregate the other modules. Omitting the module will delete the root and all modules.

Related to #246. Doesn't quite close it yet, as there should be a way to do this in the frontend.
