### PR TITLE
perf(backend): use cluster mode for the backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "lint:eslint": "eslint .",
     "lint:fix": "eslint . --fix && prettier --write .",
     "build": "tsc -b && nx run-many -t build",
-    "start:azurite": "rimraf .azurite && mkdir -p .azurite && azurite -l .azurite",
+    "start:azurite": "rimraf .azurite && mkdir -p .azurite && azurite -l .azurite --skipApiVersionCheck",
     "test": "nx run-many -t test --exclude e2e",
     "backend": "pnpm --filter @stryker-mutator/dashboard-backend",
     "badge-api": "pnpm --filter @stryker-mutator/dashboard-badge-api",

--- a/packages/website-backend/src/index.ts
+++ b/packages/website-backend/src/index.ts
@@ -1,3 +1,6 @@
+import cluster from 'node:cluster';
+import os from 'node:os';
+
 import { type INestApplication, Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import type { NestExpressApplication } from '@nestjs/platform-express';
@@ -16,7 +19,6 @@ async function bootstrap() {
 
   configureSecurityHeaders(app);
   const log = new Logger('bootstrap');
-  await configureAzureStorage(app, log);
 
   app.useBodyParser('json', { limit: '100mb' });
   app.use(compression());
@@ -26,8 +28,8 @@ async function bootstrap() {
   });
 }
 
-async function configureAzureStorage(app: INestApplication, log: Logger) {
-  const dataAccess = app.get<DataAccess>(DataAccess);
+async function configureAzureStorage(log: Logger) {
+  const dataAccess = new DataAccess();
 
   log.log('Initializing Azure Storage containers...');
   await Promise.all([
@@ -55,7 +57,26 @@ function configureSecurityHeaders(app: INestApplication) {
   );
 }
 
-bootstrap().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+/**
+ * Create a cluster of Node.js processes to take advantage of multi-core systems.
+ */
+function forkClusterWorkers(log: Logger) {
+  const numWorkers = parseInt(process.env.WEB_CONCURRENCY!, 10) || os.availableParallelism();
+  log.log(`Running with ${numWorkers} workers`);
+  // Fork workers.
+  for (let i = 0; i < numWorkers; i++) {
+    cluster.fork();
+  }
+
+  cluster.on('exit', (worker, code, signal) => {
+    log.log(`Worker ${worker.process.pid} died (${signal || code})`);
+  });
+}
+
+if (cluster.isPrimary) {
+  const log = new Logger('primary');
+  await configureAzureStorage(log);
+  forkClusterWorkers(log);
+} else {
+  await bootstrap();
+}


### PR DESCRIPTION
Before:

<img width="769" height="117" alt="image" src="https://github.com/user-attachments/assets/bf5d812c-7d4f-40cd-b62c-59146302def6" />



After:

<img width="771" height="111" alt="image" src="https://github.com/user-attachments/assets/b76be92f-b487-4d1f-8ad4-4dd84b5c262e" />

Also allows further concurrency for CPU-blocked requests