### PR TITLE
fix(security): use timing safe comparison for API key validation

### DIFF
--- a/packages/website-backend/package.json
+++ b/packages/website-backend/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "start": "node --enable-source-maps dist/index.js",
-    "start:watch": "node --watch --enable-source-maps dist/index.js",
+    "dev": "node --conditions=development --watch --enable-source-maps dist/index.js",
     "test": "c8 --check-coverage --reporter=html --report-dir=reports/coverage --lines 80 --functions 75 --branches 61 mocha --node-option enable-source-maps \"dist/test/**/*.js\"",
     "stryker": "stryker run"
   },

--- a/packages/website-backend/src/services/ApiKeyValidator.ts
+++ b/packages/website-backend/src/services/ApiKeyValidator.ts
@@ -1,5 +1,6 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import type { ProjectMapper } from '@stryker-mutator/dashboard-data-access';
+import { timingSafeEqual } from 'crypto';
 
 import util from '../utils/utils.js';
 import DataAccess from './DataAccess.js';
@@ -17,14 +18,23 @@ export class ApiKeyValidator {
     if (lastDelimiter === -1) {
       throw new HttpException(`Repository "${projectName}" is invalid`, HttpStatus.BAD_REQUEST);
     } else {
-      const projectPromise = this.#projectMapper.findOne({
+      const repo = await this.#projectMapper.findOne({
         owner: projectName.substring(0, lastDelimiter),
         name: projectName.substring(lastDelimiter + 1),
       });
-      const repo = await projectPromise;
-      if (repo?.model.apiKeyHash !== hash) {
+      const storedHash = repo?.model.apiKeyHash;
+      if (!storedHash || !hashesEqual(storedHash, hash)) {
         throw new HttpException('Invalid API key', HttpStatus.UNAUTHORIZED);
       }
     }
   }
+}
+
+/**
+ * Compare two hashes in a timing safe manner using `crypto.timingSafeEqual`
+ */
+function hashesEqual(a: string, b: string): boolean {
+  const bufferA = Buffer.from(a, 'hex');
+  const bufferB = Buffer.from(b, 'hex');
+  return bufferA.length === bufferB.length && timingSafeEqual(bufferA, bufferB);
 }

--- a/packages/website-backend/src/test/unit/controllers/auth.controller.spec.ts
+++ b/packages/website-backend/src/test/unit/controllers/auth.controller.spec.ts
@@ -19,6 +19,7 @@ describe(AuthController.name, () => {
   let user: github.Authentication;
 
   beforeEach(async () => {
+    sinon.useFakeTimers({ toFake: ['Date'] });
     user = githubFactory.authentication({ username: 'dummy' });
     sinon.stub(Strategy.prototype, 'authenticate').callsFake(function (this: Strategy) {
       this.success(user);

--- a/packages/website-backend/src/test/unit/services/ApiKeyValidator.spec.ts
+++ b/packages/website-backend/src/test/unit/services/ApiKeyValidator.spec.ts
@@ -1,0 +1,59 @@
+import { Project } from '@stryker-mutator/dashboard-data-access';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { ApiKeyValidator } from '../../../services/ApiKeyValidator.js';
+import utils from '../../../utils/utils.js';
+import { DataAccessMock } from '../../helpers/TestServer.js';
+
+describe(ApiKeyValidator.name, () => {
+  const apiKey = 'the-api-key';
+  const projectName = 'github.com/testOrg/testName';
+  let sut: ApiKeyValidator;
+  let dataAccess: DataAccessMock;
+
+  beforeEach(() => {
+    dataAccess = new DataAccessMock();
+    sut = new ApiKeyValidator(dataAccess);
+  });
+
+  function arrangeProjectWithApiKey(storedApiKey: string) {
+    const project = new Project();
+    project.apiKeyHash = utils.generateHashValue(storedApiKey);
+    dataAccess.repositoryMapper.findOne.resolves({ model: project, etag: 'etag' });
+  }
+
+  it('should resolve when the api key matches the stored hash', async () => {
+    arrangeProjectWithApiKey(apiKey);
+
+    await sut.validateApiKey(apiKey, projectName);
+
+    sinon.assert.calledWith(dataAccess.repositoryMapper.findOne, { owner: 'github.com/testOrg', name: 'testName' });
+  });
+
+  it('should reject with 401 when the api key does not match the stored hash', async () => {
+    arrangeProjectWithApiKey('a-different-key');
+
+    await expect(sut.validateApiKey(apiKey, projectName)).to.be.rejectedWith('Invalid API key');
+  });
+
+  it('should reject with 401 when the project does not exist', async () => {
+    dataAccess.repositoryMapper.findOne.resolves(undefined);
+
+    await expect(sut.validateApiKey(apiKey, projectName)).to.be.rejectedWith('Invalid API key');
+  });
+
+  it('should reject with 401 rather than throw when the stored hash has an unexpected length', async () => {
+    const project = new Project();
+    project.apiKeyHash = 'abcd'; // shorter than a real hash
+    dataAccess.repositoryMapper.findOne.resolves({ model: project, etag: 'etag' });
+
+    await expect(sut.validateApiKey(apiKey, projectName)).to.be.rejectedWith('Invalid API key');
+  });
+
+  it('should reject with 400 when the project name has no owner separator', async () => {
+    await expect(sut.validateApiKey(apiKey, 'nameWithoutSlash')).to.be.rejectedWith(
+      'Repository "nameWithoutSlash" is invalid',
+    );
+  });
+});

--- a/packages/website-backend/src/utils/utils.ts
+++ b/packages/website-backend/src/utils/utils.ts
@@ -1,6 +1,6 @@
 import { NotFoundException } from '@nestjs/common';
 import { InvalidSlugError, Slug } from '@stryker-mutator/dashboard-common';
-import { createHash, randomUUID } from 'crypto';
+import { hash, randomUUID } from 'crypto';
 
 export function parseSlug(slug: string) {
   try {
@@ -38,6 +38,6 @@ export default {
   },
 
   generateHashValue(value: string): string {
-    return createHash('sha512-256').update(value).digest('hex');
+    return hash('sha512-256', value);
   },
 };


### PR DESCRIPTION
And use the one-shot `crypto.hash` function instead of `createHash` to generate the hash value.
