### PR TITLE
perf(backend): pass raw report bytes to validator worker

### DIFF
--- a/packages/website-backend/src/controllers/reports.controller.ts
+++ b/packages/website-backend/src/controllers/reports.controller.ts
@@ -11,6 +11,8 @@ import {
   Param,
   Put,
   Query,
+  type RawBodyRequest,
+  Req,
   UseGuards,
 } from '@nestjs/common';
 import {
@@ -21,6 +23,7 @@ import {
 } from '@stryker-mutator/dashboard-common';
 import type { PutReportResponse } from '@stryker-mutator/dashboard-contract';
 import { MutationTestingReportService } from '@stryker-mutator/dashboard-data-access';
+import type { Request } from 'express';
 import type { MutationTestResult } from 'mutation-testing-report-schema';
 
 import { JwtOrApiKeyGuard } from '../auth/guard.js';
@@ -48,9 +51,12 @@ export default class ReportsController {
     @Param('slug') slug: string[],
     @Body() result: MutationScoreOnlyResult | MutationTestResult,
     @Query('module') moduleName: string | undefined,
+    @Req() request: RawBodyRequest<Request>,
   ): Promise<PutReportResponse> {
     const { project, version } = parseSlug(slug.join('/'));
-    await this.#verifyRequiredPutReportProperties(result);
+    await this.#verifyRequiredPutReportProperties(result, request.rawBody);
+    // No need to keep raw body in scope after validation
+    request.rawBody = undefined;
     this.#verifyIsCompletedReport(result);
     try {
       await this.#reportService.saveReport({ projectName: project, version, moduleName }, result, this.#logger);
@@ -133,8 +139,8 @@ export default class ReportsController {
     }
   }
 
-  async #verifyRequiredPutReportProperties(body: MutationScoreOnlyResult | MutationTestResult) {
-    const errors = await this.#reportValidator.findErrors(body);
+  async #verifyRequiredPutReportProperties(body: MutationScoreOnlyResult | MutationTestResult, rawBody?: Buffer) {
+    const errors = await this.#reportValidator.findErrors(rawBody ?? body);
     if (errors) {
       const mutationScoreOnlyResult = body as MutationScoreOnlyResult;
       if (

--- a/packages/website-backend/src/index.ts
+++ b/packages/website-backend/src/index.ts
@@ -14,6 +14,7 @@ import DataAccess from './services/DataAccess.js';
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     logger: new AppInsightsLogger('NestApplication'),
+    rawBody: true,
   });
   app.setGlobalPrefix('/api');
 

--- a/packages/website-backend/src/services/ReportValidator.ts
+++ b/packages/website-backend/src/services/ReportValidator.ts
@@ -16,7 +16,7 @@ export class ReportValidator implements OnApplicationShutdown {
     await this.#pool.terminate();
   }
 
-  public async findErrors(report: object): Promise<undefined | string> {
+  public async findErrors(report: object | Uint8Array): Promise<undefined | string> {
     return this.#pool.exec<ValidateReport>('validateReport', [report]).timeout(120_000);
   }
 

--- a/packages/website-backend/src/services/ValidatorWorker.ts
+++ b/packages/website-backend/src/services/ValidatorWorker.ts
@@ -26,8 +26,13 @@ function initSchemaValidator() {
     },
     definitions: schema.definitions,
   };
+
+  const reportSchema = structuredClone(schema);
+  const reportMutantSchema: { uniqueItems?: boolean } =
+    reportSchema.properties.files.additionalProperties.properties.mutants;
+  delete reportMutantSchema.uniqueItems;
   return {
-    fullSchemaValidate: ajv.compile<MutationTestResult>(schema),
+    fullSchemaValidate: ajv.compile<MutationTestResult>(reportSchema),
     mutantSchemaValidate: ajv.compile<Partial<MutantResult>[]>(mutantSchema),
     errorsText: ajv.errorsText.bind(ajv),
   };
@@ -47,8 +52,39 @@ function validate<T>(data: unknown, validator: ValidateFunction<T>): undefined |
   }
 }
 
-function validateReport(report: object): undefined | string {
-  return validate(report, fullSchemaValidate);
+/**
+ * Simpler `uniqueItems` constraint of the schema `files[*].mutants`
+ */
+function findDuplicateMutantId(report: MutationTestResult): undefined | string {
+  for (const [fileName, file] of Object.entries(report.files ?? {})) {
+    const ids = new Set<string>();
+    for (const { id } of file.mutants) {
+      if (ids.has(id)) {
+        return `data/files/${fileName.replace(/~/g, '~0').replace(/\//g, '~1')}/mutants must not contain duplicate mutant ids (duplicate id: "${id}")`;
+      }
+      ids.add(id);
+    }
+  }
+  return;
+}
+
+function validateReport(report: object | Uint8Array): undefined | string {
+  let parsed: object;
+  if (report instanceof Uint8Array) {
+    try {
+      parsed = JSON.parse(Buffer.from(report.buffer, report.byteOffset, report.byteLength).toString('utf8')) as object;
+    } catch (err) {
+      return `Invalid JSON: ${(err as Error).message}`;
+    }
+  } else {
+    parsed = report;
+  }
+
+  const schemaError = validate(parsed, fullSchemaValidate);
+  if (schemaError) {
+    return schemaError;
+  }
+  return findDuplicateMutantId(parsed as MutationTestResult);
 }
 export type ValidateReport = typeof validateReport;
 

--- a/packages/website-backend/src/test/unit/services/ReportValidator.spec.ts
+++ b/packages/website-backend/src/test/unit/services/ReportValidator.spec.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import type { MutantResult } from 'mutation-testing-report-schema/api';
 
 import { ReportValidator } from '../../../services/ReportValidator.js';
+import { createMutationTestResult } from '../../helpers/mutants.js';
 
 describe(ReportValidator.name, () => {
   let sut: ReportValidator;
@@ -12,6 +13,46 @@ describe(ReportValidator.name, () => {
 
   afterEach(async () => {
     await sut.onApplicationShutdown();
+  });
+
+  describe('findErrors', () => {
+    it('should accept a valid report', async () => {
+      expect(await sut.findErrors(createMutationTestResult())).to.be.undefined;
+    });
+
+    it('should accept a valid report handed over as raw bytes', async () => {
+      const raw = Buffer.from(JSON.stringify(createMutationTestResult()), 'utf8');
+
+      expect(await sut.findErrors(raw)).to.be.undefined;
+    });
+
+    it('should report schema errors for a report handed over as raw bytes', async () => {
+      const raw = Buffer.from(JSON.stringify({ schemaVersion: '1', files: {} }), 'utf8');
+
+      expect(await sut.findErrors(raw)).to.be.eq("data must have required property 'thresholds'");
+    });
+
+    it('should report unparsable raw bytes rather than throwing', async () => {
+      const errors = await sut.findErrors(Buffer.from('{not json', 'utf8'));
+
+      expect(errors).to.include('Invalid JSON');
+    });
+
+    it('should reject a report with duplicate mutant ids in one file', async () => {
+      const report = createMutationTestResult(['Killed', 'Survived']);
+      report.files['a.js'].mutants[1].id = report.files['a.js'].mutants[0].id;
+
+      const errors = await sut.findErrors(report);
+
+      expect(errors).to.be.eq('data/files/a.js/mutants must not contain duplicate mutant ids (duplicate id: "0")');
+    });
+
+    it('should allow the same mutant id in different files', async () => {
+      const report = createMutationTestResult(['Killed']);
+      report.files['b.js'] = structuredClone(report.files['a.js']);
+
+      expect(await sut.findErrors(report)).to.be.undefined;
+    });
   });
 
   describe('validateMutants', () => {


### PR DESCRIPTION
Instead of needing to serialize and deserialize between the worker and main process.

Also skip the `uniqueItems` constraint and instead check duplicate mutant ids using a `Set`.
