### PR TITLE
fix: issuer metadata for GitHub auth

### DIFF
--- a/packages/website-backend/src/github/Strategy.ts
+++ b/packages/website-backend/src/github/Strategy.ts
@@ -8,7 +8,7 @@ import GithubAgent, { GITHUB_BACKEND } from './GithubAgent.js';
 import type { Authentication } from './models.js';
 
 const GITHUB_SERVER_METADATA: client.ServerMetadata = Object.freeze({
-  issuer: 'https://github.com',
+  issuer: 'https://github.com/login/oauth',
   authorization_endpoint: 'https://github.com/login/oauth/authorize',
   token_endpoint: 'https://github.com/login/oauth/access_token',
   userinfo_endpoint: `${GITHUB_BACKEND}/user`,

--- a/packages/website-backend/src/test/unit/controllers/auth.controller.spec.ts
+++ b/packages/website-backend/src/test/unit/controllers/auth.controller.spec.ts
@@ -138,6 +138,26 @@ describe(AuthController.name, () => {
       });
     });
 
+    it('should accept the issuer GitHub identifies itself with', async () => {
+      // Arrange
+      const { cookie, state } = await beginAuthorization();
+
+      // Act & Assert
+      await exchange({ code: 'the-authorization-code', state, iss: 'https://github.com/login/oauth' })
+        .set('Cookie', cookie)
+        .expect(201);
+    });
+
+    it('should reject an authorization response from another issuer', async () => {
+      // Arrange
+      const { cookie, state } = await beginAuthorization();
+
+      // Act & Assert
+      await exchange({ code: 'the-authorization-code', state, iss: 'https://github.example.org/login/oauth' })
+        .set('Cookie', cookie)
+        .expect(401);
+    });
+
     it('should reject an authorization response without the state cookie', async () => {
       // Arrange
       const { state } = await beginAuthorization();

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -59,7 +59,7 @@
       "**/*.code-search": true,
       "**/dist": true,
     },
-    "typescript.tsdk": "stryker-dashboard\\node_modules\\typescript\\lib",
+    "js/ts.tsdk.path": "root/node_modules/typescript/lib",
     "cSpell.words": ["Clazz", "clippy", "etag", "fdescribe", "gitlab", "Testabilities"],
     "task.autoDetect": "off",
     "azurite.location": "root/.azurite",


### PR DESCRIPTION
Fixes #2156, #2167

Sets correct `issuer` metadata for GitHub auth strategy